### PR TITLE
Make types and optional types inferable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "envfefe",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.integration.test.ts
+++ b/src/index.integration.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { parse, sanitize } from './index';
 
 describe('integration tests', () => {
-  let originalEnv;
+  let originalEnv: NodeJS.ProcessEnv;
   beforeEach(() => {
     originalEnv = process.env;
     process.env = {...process.env};

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -4,7 +4,7 @@ import { parse, parseEnv } from './parse';
 import * as sanitize from './sanitize';
 
 describe('parse', () => {
-  let originalEnv;
+  let originalEnv: NodeJS.ProcessEnv;
   beforeEach(() => {
     originalEnv = process.env;
     process.env = {...process.env};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "outDir": "build",
     "rootDir": "./src",
+    "strict": true,
     "sourceMap": true,
     "target": "es6"
   }


### PR DESCRIPTION
This PR is an improvement on the previous one (#27) as it will also correctly infer what types are optional.

Bonus: `Object.keys(...).forEach(...)` is back.
Also: this required to make the TypeScript settings `strict`.

Example:
```typescript
const config = parse({
  elasticHost: sanitize.string,
  elasticPort: sanitize.number,
  enableCache: {
    sanitize: sanitize.boolean,
    optional: true,
  },
  gcloudCredentials: sanitize.json,
  launchDate: sanitize.date,
  whitelist: {
    sanitize: value => sanitize.string(value).split(','),
    optional: true,
  }
});

type Config = typeof config;
```

Result: 
```typescript
type Config = {
    elasticHost: string;
    elasticPort: number;
    enableCache: boolean | undefined;
    gcloudCredentials: any;
    launchDate: Date;
    whitelist: string[] | undefined;
}
```

### Caveats
Due to limitations of TypeScript (automatic widening of literal types) for this to work the typing of `parse` explicitely forbids to specify `optional: false` anywhere in the options (rather you have to leave `optional` out – it is `false` by default):

```typescript
// TypeScript error: Type 'false' is not assignable to type 'true | undefined'.
parse({
  nonOptional: {
    sanitize: (value: string) => value,
    optional: false,
  }
});
```

