### PR TITLE
Infer optional types

### DIFF
--- a/src/index.integration.test.ts
+++ b/src/index.integration.test.ts
@@ -26,7 +26,7 @@ describe('integration tests', () => {
 
     expect(parse({
       booleanVar: sanitize.boolean,
-      customVar: (value: string) => sanitize.string(value).split(','),
+      customVar: value => sanitize.string(value).split(','),
       dateVar: sanitize.date,
       defaultVar: {sanitize: sanitize.number, default: 1.337},
       jsonVar: sanitize.json,

--- a/src/index.integration.test.ts
+++ b/src/index.integration.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { parse, sanitize } from './index';
 
 describe('integration tests', () => {
-  let originalEnv;
+  let originalEnv: NodeJS.ProcessEnv;
   beforeEach(() => {
     originalEnv = process.env;
     process.env = {...process.env};
@@ -26,7 +26,7 @@ describe('integration tests', () => {
 
     expect(parse({
       booleanVar: sanitize.boolean,
-      customVar: value => sanitize.string(value).split(','),
+      customVar: (value: string) => sanitize.string(value).split(','),
       dateVar: sanitize.date,
       defaultVar: {sanitize: sanitize.number, default: 1.337},
       jsonVar: sanitize.json,

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -4,7 +4,7 @@ import { parse, parseEnv } from './parse';
 import * as sanitize from './sanitize';
 
 describe('parse', () => {
-  let originalEnv;
+  let originalEnv: NodeJS.ProcessEnv;
   beforeEach(() => {
     originalEnv = process.env;
     process.env = {...process.env};

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,7 +1,5 @@
 import constantCase = require('constant-case');
 
-import * as sanitize from './sanitize';
-
 export type EnvSanitize<R> = ((v: string) => R);
 
 export interface IEnvOptions<R> {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -19,7 +19,7 @@ export interface IGetEnvOptions<R> extends IEnvOptions<R> {
   name: string;
 }
 
-export function parseEnv<R>(options: IGetEnvOptions<R>): R {
+export function parseEnv<R>(options: IGetEnvOptions<R>): R | undefined {
   const envValue = process.env[options.name];
 
   if (!envValue) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "build",
     "rootDir": "./src",
     "sourceMap": true,
+    "strict": true,
     "target": "es6"
   }
 }


### PR DESCRIPTION
This is based on #29 and uses a simplified return type extraction that does not suffer from the problem where `optional: false` becomes invalid (which would be a backward-incompatible change).